### PR TITLE
[PATCH] Removed Firefox specific mousemove event listener

### DIFF
--- a/src/HTML5Backend.js
+++ b/src/HTML5Backend.js
@@ -176,21 +176,11 @@ export default class HTML5Backend {
     this.currentNativeSource = new SourceType();
     this.currentNativeHandle = this.registry.addSource(type, this.currentNativeSource);
     this.actions.beginDrag([this.currentNativeHandle]);
-
-    // On Firefox, if mousemove fires, the drag is over but browser failed to tell us.
-    // This is not true for other browsers.
-    if (isFirefox()) {
-      window.addEventListener('mousemove', this.endDragNativeItem, true);
-    }
   }
 
   endDragNativeItem() {
     if (!this.isDraggingNativeItem()) {
       return;
-    }
-
-    if (isFirefox()) {
-      window.removeEventListener('mousemove', this.endDragNativeItem, true);
     }
 
     this.actions.endDrag();


### PR DESCRIPTION
Dropping files doesn't work in Firefox 45 when dropping while dragging, doesn't work at all in Firefox 47.

From PR: https://github.com/gaearon/react-dnd-html5-backend/pull/34
By: Evert Bouw evert.bouw@webpower.nl
