### PR TITLE
Fixed dragging from textarea in firefox

### DIFF
--- a/src/HTML5Backend.js
+++ b/src/HTML5Backend.js
@@ -268,7 +268,15 @@ export default class HTML5Backend {
     });
 
     const { dataTransfer } = e;
-    const nativeType = matchNativeItemType(dataTransfer);
+    let nativeType = null;
+    // Dragging from firefox will sometimes make its dataTransfer object un-readable
+    try {
+      nativeType = matchNativeItemType(dataTransfer);
+    } catch (err) {
+      // If it's not readable, we just let it drag. Because we assume that
+      // it is a native type and will be picked up in dragenter handler.
+      return;
+    }
 
     if (this.monitor.isDragging()) {
       if (typeof dataTransfer.setDragImage === 'function') {


### PR DESCRIPTION
The bug happened in firefox when user is trying to drag text from textarea. It turns out that in the drag start event, the DataTransfer object is un-readable. Any attempt to read from this object will result in an Error message: Permission denied to access property XXX.

I'm still not sure what caused this. There are 2 potential reasons in mind:
1) According to MDN the permission error is caused by <iframe> violating the same-origin policy. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Property_access_denied
But in our case we aren't using <iframe>
2) There is a "protected mode" for the dnd event. During protected mode, data transfer data will be unavailable. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Property_access_denied
However this mode doesn't happen during drag start. But we are hitting this during drag start.

This error only gets hit during drag start. It won't happen during drag enter.
Though the cause is still unclear, I added a patch to avoid hitting the error:
Since it's about dragging a native TEXTAREA target, before accessing data transfer, let it return so browser will take care of this native drag event.

https://app.asana.com/0/47286296812336/157679098111561