### PR TITLE
End the old drag if you beginDrag while dragging

### DIFF
--- a/src/HTML5Backend.js
+++ b/src/HTML5Backend.js
@@ -260,6 +260,11 @@ export default class HTML5Backend {
 
     const clientOffset = getEventClientOffset(e);
 
+    // Avoid crashing if we missed a drop event or our previous drag died
+    if (this.monitor.isDragging()) {
+      this.actions.endDrag();
+    }
+
     // Don't publish the source just yet (see why below)
     this.actions.beginDrag(dragStartSourceIds, {
       publishSource: false,


### PR DESCRIPTION
This patches an invariant crash in ReactDND, where
browsers will sometimes allow ReactDND to get stuck
in a permanent 'dragging' state. If you beginDrag
while already dragging, it crashes, so here we detect
that and end the old drag first.

https://app.asana.com/0/inbox/105283639970709/257965941682512/260987766640638

CC @Josh211ua (while @zhiyiting is out) and @scottcheng 