### PR TITLE
Early return if you drop while not dragging

### DIFF
--- a/src/HTML5Backend.js
+++ b/src/HTML5Backend.js
@@ -492,6 +492,11 @@ export default class HTML5Backend {
     const { dropTargetIds } = this;
     this.dropTargetIds = [];
 
+    // Avoid crashing if we are not dragging anything
+    if (!this.monitor.isDragging()) {
+      return;
+    }
+
     this.actions.hover(dropTargetIds, {
       clientOffset: getEventClientOffset(e)
     });


### PR DESCRIPTION
Similar to https://github.com/Asana/react-dnd-html5-backend/pull/6, patch an invariant crash in ReactDnd. We detect if it's not in a dragging state, but it is trying to call drop action, we catch that and early return.
However I don't feel like I understand the root cause about why this is happening :(
https://app.asana.com/0/1149204378422/177191634313359