### PR TITLE
Prevent access denied from crashing, and add logging

### DIFF
--- a/src/HTML5Backend.js
+++ b/src/HTML5Backend.js
@@ -460,10 +460,30 @@ export default class HTML5Backend {
 
   handleTopDragLeaveCapture(e) {
     if (this.isDraggingNativeItem()) {
-      e.preventDefault();
+      // ##FirefoxPermissionDenied
+      // In Firefox sometimes preventDefault is not accessible on e. This adds
+      // temporary logging so hopefully we will learn more about this error.
+      // https://app.asana.com/0/1149204378422/334924376407244
+      try {
+        e.preventDefault();
+      } catch (err) {
+        host && host.recordWarning && host.recordWarning( // eslint-disable-line
+          'Error when trying to access e.preventDefault in handleTopDragLeaveCapture',
+          this.monitor.getItemType()
+        );
+      }
     }
 
-    const isLastLeave = this.enterLeaveCounter.leave(e.target);
+    let isLastLeave = false;
+    // #FirefoxPermissionDenied
+    try {
+      isLastLeave = this.enterLeaveCounter.leave(e.target);
+    } catch (err) {
+      host && host.recordWarning && host.recordWarning( // eslint-disable-line
+        'Error when trying to access e.target in handleTopDragLeaveCapture',
+        this.monitor.getItemType()
+      );
+    }
     if (!isLastLeave) {
       return;
     }


### PR DESCRIPTION
We have [a very bad Firefox dnd bug](https://app.asana.com/0/148675973320328/334924376407244) that's coming from this library. I don't fully understand what's causing this yet, and we're not able to repro. This commit prevents it from crashing when this error happens, and logs what is being dragged.

Looks like we had a similar bug fix before (#4). Assigning to @Josh211ua since you reviewed that change and hopefully have some context. cc @epelz as previous ReactDnd AoR holder.

https://app.asana.com/0/1149204378422/334924376407244
