### PR TITLE
Early return on undefined drag preview

### DIFF
--- a/src/OffsetUtils.js
+++ b/src/OffsetUtils.js
@@ -24,6 +24,13 @@ export function getEventClientOffset(e) {
 }
 
 export function getDragPreviewOffset(sourceNode, dragPreview, clientOffset, anchorPoint) {
+  // https://app.asana.com/0/1149204378422/1119566821863177
+  // Return early with no offset if dragPreview is undefined
+  // This occurs rarely and is a known issue: https://github.com/react-dnd/react-dnd/issues/971
+  if (!dragPreview) {
+    return { x: 0, y: 0 };
+  }
+
   // The browsers will use the image intrinsic size under different conditions.
   // Firefox only cares if it's an image, but WebKit also wants it to be detached.
   const isImage = dragPreview.nodeName === 'IMG' && (


### PR DESCRIPTION
This is a low occurrence error due to a ReactDnd bug that is thrown when ReactDnd tries to compute a drag preview offset when the drag preview is undefined.

Coincidentally others in the community have reported it in relation to a "boards-like" application as well: react-dnd/react-dnd#971, but no fix has been committed to the library yet. It looks like the source of the error is when we check for nodeName here and the node is null: https://github.com/react-dnd/react-dnd/blob/master/packages/core/html5-backend/src/OffsetUtils.ts#L27

https://app.asana.com/0/750765658990785/1119566821863177