### PR TITLE
Fix undefined dragPreview issue again

### DIFF
--- a/src/HTML5Backend.js
+++ b/src/HTML5Backend.js
@@ -310,15 +310,23 @@ export default class HTML5Backend {
         const sourceId = this.monitor.getSourceId();
         const sourceNode = this.sourceNodes[sourceId];
         const dragPreview = this.sourcePreviewNodes[sourceId] || sourceNode;
-        const { anchorX, anchorY } = this.getCurrentSourcePreviewNodeOptions();
-        const anchorPoint = { anchorX, anchorY };
-        const dragPreviewOffset = getDragPreviewOffset(
-          sourceNode,
-          dragPreview,
-          clientOffset,
-          anchorPoint
-        );
-        dataTransfer.setDragImage(dragPreview, dragPreviewOffset.x, dragPreviewOffset.y);
+
+        // ##NoDragPreview
+        // https://app.asana.com/0/750765658990785/1169293839100683
+        // https://app.asana.com/0/1149204378422/1119566821863177
+        // Don't do anything if dragPreview is undefined, otherwise the application will crash.
+        // This occurs rarely and is a known issue: https://github.com/react-dnd/react-dnd/issues/971
+        if (dragPreview) {
+          const { anchorX, anchorY } = this.getCurrentSourcePreviewNodeOptions();
+          const anchorPoint = { anchorX, anchorY };
+          const dragPreviewOffset = getDragPreviewOffset(
+            sourceNode,
+            dragPreview,
+            clientOffset,
+            anchorPoint
+          );
+          dataTransfer.setDragImage(dragPreview, dragPreviewOffset.x, dragPreviewOffset.y);
+        }
       }
 
       try {

--- a/src/OffsetUtils.js
+++ b/src/OffsetUtils.js
@@ -24,13 +24,6 @@ export function getEventClientOffset(e) {
 }
 
 export function getDragPreviewOffset(sourceNode, dragPreview, clientOffset, anchorPoint) {
-  // https://app.asana.com/0/1149204378422/1119566821863177
-  // Return early with no offset if dragPreview is undefined
-  // This occurs rarely and is a known issue: https://github.com/react-dnd/react-dnd/issues/971
-  if (!dragPreview) {
-    return { x: 0, y: 0 };
-  }
-
   // The browsers will use the image intrinsic size under different conditions.
   // Firefox only cares if it's an image, but WebKit also wants it to be detached.
   const isImage = dragPreview.nodeName === 'IMG' && (


### PR DESCRIPTION
Sorry, my initial fix from https://github.com/Asana/react-dnd-html5-backend/pull/10 was not actually complete, because although an drag preview offset was defined, the application will still crash when it tries to render a dragPreview that is undefined. 

Let's handle this error upstream in `handleTopDragStart` instead. I confirmed that this is the only place where `getDragPreviewOffset` is called.